### PR TITLE
adds homebrew to $path for apple m1

### DIFF
--- a/runcoms/zprofile
+++ b/runcoms/zprofile
@@ -44,6 +44,7 @@ typeset -gU cdpath fpath mailpath path
 # Set the list of directories that Zsh searches for programs.
 path=(
   /usr/local/{bin,sbin}
+  /opt/homebrew/{bin,sbin}
   $path
 )
 


### PR DESCRIPTION
adds `/opt/homebrew/{bin,sbin}` to `$path` on apple m1 architecture.